### PR TITLE
Remove redundant statements.

### DIFF
--- a/src/main/java/com/flipkart/lois/Lois.java
+++ b/src/main/java/com/flipkart/lois/Lois.java
@@ -48,7 +48,7 @@ public class Lois {
      */
     public static void go(List<Routine> routines) {
         for (Routine routine: routines){
-            executorService.execute((Runnable)routine);
+            executorService.execute(routine);
         }
     }
 

--- a/src/main/java/com/flipkart/lois/channel/impl/BufferedChannel.java
+++ b/src/main/java/com/flipkart/lois/channel/impl/BufferedChannel.java
@@ -87,7 +87,7 @@ public class BufferedChannel<T> implements Channel<T> {
 
     @Override
     public void send(final T message, final long timeOut, final TimeUnit timeUnit) throws ChannelClosedException, InterruptedException, TimeoutException {
-        boolean sent=false;
+        boolean sent;
         if(isOpen())
             sent = buffer.offer(replicateMessage(message), timeOut, timeUnit);
         else


### PR DESCRIPTION
- Redundant casting for runnable object.
- Variable initializer "false" is redundant.
